### PR TITLE
Remove .idea/ and *.iml from .gitignore (Needed for committing IntelliJ IDEA Plugin Project)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,7 +9,6 @@ bin/
 *.ldb
 _ReSharper*/
 *.iws
-*.iml
 *.ipr
 *.eml
 out/
@@ -26,5 +25,4 @@ Out*/
 .settings/
 *.lic
 Data/*Out*
-.idea/
 .project


### PR DESCRIPTION
Remove .idea/ and *.iml from .gitignore (Needed for committing IntelliJ IDEA Plugin Project)

Signed-off-by: AdeelIlyas2014 adeel.ilyas@aspose.com
